### PR TITLE
Ensure DoT settings and validate configuration

### DIFF
--- a/AppleDNS-DoT.mobileconfig
+++ b/AppleDNS-DoT.mobileconfig
@@ -6,12 +6,16 @@
 	<array>
 		<dict>
 			<key>DNSSettings</key>
-			<dict>
-				<key>ServerAddresses</key>
-				<array>
-					<string>114.114.114.114</string>
-				</array>
-			</dict>
+                        <dict>
+                                <key>DNSProtocol</key>
+                                <string>TLS</string>
+                                <key>ServerAddresses</key>
+                                <array>
+                                        <string>114.114.114.114</string>
+                                </array>
+                                <key>ServerName</key>
+                                <string>dot.114dns.com</string>
+                        </dict>
 			<key>PayloadDescription</key>
 			<string>设置你的移动端苹果设备 DNS 为 114.114.114.114</string>
 			<key>PayloadDisplayName</key>
@@ -20,8 +24,8 @@
 			<string>cc.custom.dnsSettings.managed</string>
 			<key>PayloadType</key>
 			<string>com.apple.dnsSettings.managed</string>
-			<key>PayloadUUID</key>
-			<string>12345678-1234-1234-1234-123456789abc</string>
+                        <key>PayloadUUID</key>
+                        <string>25E9EF21-965A-4B4C-8F07-630BFBAD9C8E</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
 		</dict>
@@ -34,8 +38,8 @@
 	<string>cc.custom.dns</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>12345678-1234-1234-1234-123456789abc</string>
+        <key>PayloadUUID</key>
+        <string>F8A47B9E-18F4-4C3E-A0F5-A9025289A7A6</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
 </dict>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 114 的 DNS 可以解决很多解析错误的问题，如果需要其他地址的 DNS 可以 fork 一下然后修改对应字段即可，安装方式同上。
 
-另一个更好的方法是直接使用 surger 来按需指定 DNS，更方便更灵活，有需要可以自行谷歌。
+另一个更好的方法是直接使用 Surge 来按需指定 DNS，更方便更灵活，有需要可以自行谷歌。
+
+该描述文件启用了基于 TLS 的加密 DNS（DoT），服务器名称设定为 dot.114dns.com，对应的服务器地址为 114.114.114.114，与上文描述保持一致。
 
 https://raw.githubusercontent.com/robbit69/AppleDNS/refs/heads/master/AppleDNS-DoT.mobileconfig

--- a/tests/test_mobileconfig.py
+++ b/tests/test_mobileconfig.py
@@ -1,0 +1,25 @@
+import plistlib
+from pathlib import Path
+
+
+def load_mobileconfig():
+    config_path = Path(__file__).resolve().parents[1] / "AppleDNS-DoT.mobileconfig"
+    with config_path.open("rb") as handle:
+        return plistlib.load(handle)
+
+
+def test_payload_uuids_are_unique():
+    config = load_mobileconfig()
+    top_uuid = config["PayloadUUID"]
+    child_payloads = config["PayloadContent"]
+    assert child_payloads, "PayloadContent should not be empty"
+    child_uuid = child_payloads[0]["PayloadUUID"]
+    assert top_uuid != child_uuid, "Top level and child payload UUIDs must differ"
+
+
+def test_dns_settings_enable_dot():
+    config = load_mobileconfig()
+    dns_settings = config["PayloadContent"][0]["DNSSettings"]
+    assert dns_settings["DNSProtocol"] == "TLS"
+    assert dns_settings["ServerName"] == "dot.114dns.com"
+    assert dns_settings["ServerAddresses"] == ["114.114.114.114"]


### PR DESCRIPTION
## Summary
- document the TLS-based DoT settings in the README and fix a spelling error
- update the mobileconfig payload to use TLS DoT with a unique UUID for each payload
- add pytest coverage that validates the DoT configuration and UUID uniqueness

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d568a9ebac8328a06aec8d229ee9e0